### PR TITLE
Try to support Bitbucket 7.2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target/
+*.iml
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.cyanoth</groupId>
     <artifactId>eagerpr</artifactId>
-    <version>0.1.5</version>
+    <version>0.2.0</version>
     <packaging>atlassian-plugin</packaging>
 
     <name>Eager PullRequest Internal-Refs Update</name>
@@ -21,7 +21,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <amps.version>8.0.2</amps.version>
-        <bitbucket.version>7.1.2</bitbucket.version>
+        <bitbucket.version>7.2.5</bitbucket.version>
         <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version>
 
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->


### PR DESCRIPTION
Regarding issue #2 I have tried to build the plugin myself using atlasssian-sdk 8.0.16. The plugin is installable and runs and I can confirm the update of the refs is triggered:

```
2020-06-26 20:28:27,397 DEBUG [AtlassianEvent::thread-2]  c.c.eagerpr.InternalPRRefRefresh EagerPr: RefreshInternalPRRefresh triggered internal ref update for pull-request id: 25 repository: playground-service it took: 139ms
```

Still the refs do NOT get updated. Doing a `git ls-remote` does not show a ref ending with `/merge` for the offending PR.

This merge request is intended to be used as a working base.